### PR TITLE
Correct build issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/tstout/fin-kratzen"
   :license {:name "MIT"
             :url  "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.9.229" :exclusions [org.clojure/clojure junit]]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [org.clojure/tools.nrepl "0.2.13"]

--- a/src/kratzen/config.clj
+++ b/src/kratzen/config.clj
@@ -1,26 +1,66 @@
 (ns kratzen.config
   (:require [clojure.edn :as edn]
-            [clojure.java.io :as io]))
-;;
+            [clojure.java.io :refer [resource
+                                     as-file
+                                     file
+                                     make-parents
+                                     output-stream
+                                     writer]]
+            [clojure.pprint :refer [pprint pp]]))
 
 (defn load-config
   "Load configuration from ~/.fin-kratzen/config.clj
    The config must be in EDN format."
   []
   (-> (System/getProperty "user.home")
-      (io/file ".fin-kratzen/config.clj")
+      (file ".fin-kratzen/config.clj")
       slurp
       edn/read-string))
+
+(def cfg-file
+  (->
+      "user.home"
+      System/getProperty
+      (file ".fin-kratzen/config.clj")))
+
+(def stub-config
+  {:boa {:user ""
+         :pass ""
+         :account ""
+         :routing ""
+         :client-id ""
+         :db-user ""
+         :db-pass ""}
+   :email {:user ""
+           :pass ""}})
+
+(defn mk-config []
+  (when-not (.exists cfg-file)
+    (make-parents cfg-file)
+    (with-open [out (writer (output-stream cfg-file))]
+      (pprint stub-config out))))
+
+(defn load-config
+  "Load configuration from ~/.fin-kratzen/config.clj
+   The config must be in EDN format."
+  []
+  (mk-config)
+  (-> cfg-file
+      slurp
+      edn/read-string))
+
+(def cfg (load-config))
+
 
 (defn
   load-res [res]
   (-> res
-      io/resource
+      resource
       slurp))
 
 (defn load-edn-resource [res]
   (->> res
-       io/resource
+       resource
        slurp
        edn/read-string))
 

--- a/src/kratzen/db.clj
+++ b/src/kratzen/db.clj
@@ -30,6 +30,7 @@
         boa (:boa cfg)]
     (zipmap [:user :pass] [(:db-user boa) (:db-pass boa)])))
 
+
 (defn db-conn-factory
   "Create a DB connection factory using db.io"
   [db-vendor]


### PR DESCRIPTION
When trying to build on a new machine, the
compile failed if the config file did not exist.
This was corrected by creating a stub file if it does
not exist.

In addition, updated clojure version to 1.10.0.